### PR TITLE
Added 'data' as a query-param and a link to save progress

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,9 @@
                  [bidi "2.1.6"]
                  [cljsjs/quill "1.3.7-0"]
                  [district0x/re-frame-window-fx "1.1.0"]
-                 [kibu/pushy "0.3.8"]]
+                 [kibu/pushy "0.3.8"]
+                 [lambdaisland/uri "1.4.54"]
+                 ]
 
   :plugins [[lein-shadow "0.3.1"]
             [lein-less "1.7.5"]

--- a/src/cljs/text_to_wardley/core.cljs
+++ b/src/cljs/text_to_wardley/core.cljs
@@ -6,6 +6,8 @@
    [text-to-wardley.routes :as routes]
    [text-to-wardley.views :as views]
    [text-to-wardley.config :as config]
+   [text-to-wardley.subs :as subs]
+   [text-to-wardley.db :as db]
    ))
 
 

--- a/src/cljs/text_to_wardley/db.cljs
+++ b/src/cljs/text_to_wardley/db.cljs
@@ -4,11 +4,11 @@
    [clojure.pprint :as pp]
    [clojure.set :as set]
    [text-to-wardley.config :as config]
-   ))
+   [goog.crypt.base64 :as b64]))
 
 (def starting-editor-value
   (str
-"Customer:
+   "Customer:
 	 Evolution: Custom Built, 65%
 	 Visible: 98%
 	 Needs: Online Image Manipulation, Online Photo Storage, Web Site, Print
@@ -46,9 +46,9 @@ Data Center:
          Needs: Power
 Power:
 	 Evolution: Commodity, 30%
-	 Visible: 10%"
-))
+	 Visible: 10%"))
 
+(def max-data-length 2048) ;; TODO
 
 (defn trace [message res]
   (println (str "TRACE: " message res))
@@ -58,10 +58,10 @@ Power:
   (if (nil? line)
     false
     (if (and
-       (not (str/starts-with? line "\t"))
-       (str/ends-with? line ":"))
-    true
-    false)))
+         (not (str/starts-with? line "\t"))
+         (str/ends-with? line ":"))
+      true
+      false)))
 
 (defn merge-other-key [key acc record]
   (let [acc-other (key acc [])
@@ -76,8 +76,7 @@ Power:
             new-sub (if (nil? (:other (node record)))
                       (merge (node acc) (node record))
                       (merge (node acc) (merge-other-key node acc record)))
-            new-acc (merge acc {node new-sub})
-            ]
+            new-acc (merge acc {node new-sub})]
         (recur new-acc (nthnext remaining 1)))
       acc)))
 
@@ -114,8 +113,7 @@ Power:
     (if (in? phases phase)
       {:Evolution {:phase phase
                    :x-axis x-axis}}
-      {:other [(:original sub-node)]})
-    ))
+      {:other [(:original sub-node)]})))
 
 (defmethod parse-content :Visible [sub-node]
   (let [y-axis (str/replace (str/trim (:Visible sub-node)) #"%" "")]
@@ -123,8 +121,7 @@ Power:
 
 (defmethod parse-content :Needs [sub-node]
   (let [tokens (str/split (:Needs sub-node) #", ")
-        nodes (into [] (remove nil? (map #(keywordize-node (str/trim %)) tokens)))
-        ]
+        nodes (into [] (remove nil? (map #(keywordize-node (str/trim %)) tokens)))]
     {:Needs {:links nodes}}))
 
 (defmethod parse-content :default [sub-node]
@@ -135,8 +132,7 @@ Power:
   (let [tokens       (str/split line #":")
         start-token  (keyword (keywordize-node (first tokens)))
         contents     (map str/trim (nthnext tokens 1))
-        partial   {start-token (first (vec contents)) :original line}
-        ]
+        partial   {start-token (first (vec contents)) :original line}]
     {node (parse-content partial)}))
 
 
@@ -156,32 +152,44 @@ Power:
   (let [lines (str/split-lines text)]
     (loop [acc-trees []
            remaining-lines lines
-           node nil
-           ]
+           node nil]
       (if-let [line (first remaining-lines)]
         (let [full-line-result (parse-line line {} node)
               line-result (first full-line-result)
-              new-node (last full-line-result)
-              acc-trees (if (not (nil? line-result))
+              new-node (trace "new-node->" (last full-line-result))
+              acc-trees (if (and (not (nil? new-node)) 
+                                 (not (nil? line-result)))
                           (conj acc-trees line-result)
                           acc-trees)]
           (recur acc-trees (nthnext remaining-lines 1) new-node))
-        (merge-nodes acc-trees)))))
+        (merge-nodes (trace "acc-trees -> " acc-trees))))))
+
+
+
+
+(defn decode-qp-text [qp-text]
+  (let [json (trace "decode->" (b64/decodeString qp-text))
+        map (try
+              (js->clj (.parse js/JSON json) :keywordize-keys true)
+              (catch js/Error e
+                (println "Error occured: " e)
+                {:text qp-text}
+                )
+              )]
+    (:text map)))
+
+(defn encode-qp-text [text]
+  (let [json (.stringify js/JSON (clj->js {:version "v1" :text text}))
+        base64 (b64/encodeString json)]
+    base64))
+
 
 (defn populate-editor [text]
-  {:parsed (parse text) :raw text})
-
-
-
+  {:parsed (parse text) :raw text :encoded (encode-qp-text text)})
 
 ;; The DB riiight down the bottom.
 
 (def default-db
-  {:name "re-frame"
-   :editor (populate-editor starting-editor-value)
-   :window-size {:width js/window.innerWidth, :height js/window.innerHeight}})
-
-
-
-
-(into [] (remove nil? (map #(keywordize-node (str/trim %)) [""])))
+      {:name "re-frame"
+       :editor {:parsed {} :raw ""}
+       :window-size {:width js/window.innerWidth, :height js/window.innerHeight}})

--- a/src/cljs/text_to_wardley/events.cljs
+++ b/src/cljs/text_to_wardley/events.cljs
@@ -17,9 +17,9 @@
    {:navigate handler}))
 
 (re-frame/reg-event-fx
- ::set-active-panel
- (fn-traced [{:keys [db]} [_ active-panel]]
-   {:db (assoc db :active-panel active-panel)}))
+ ::set-navigation
+ (fn-traced [{:keys [db]} [_ navigation]]
+   {:db (assoc db :navigation navigation)}))
 
 (re-frame/reg-event-fx
  ::update-editor-contents

--- a/src/cljs/text_to_wardley/subs.cljs
+++ b/src/cljs/text_to_wardley/subs.cljs
@@ -10,7 +10,7 @@
 (re-frame/reg-sub
  ::active-panel
  (fn [db _]
-   (:active-panel db)))
+   (:panel (:navigation db))))
 
 (re-frame/reg-sub
  ::editor-raw
@@ -26,3 +26,13 @@
  ::window-size
  (fn [db _]
    (:window-size db)))
+
+(re-frame/reg-sub
+ ::query-params
+ (fn [db _]
+   (:query-params (:navigation db))))
+
+(re-frame/reg-sub
+ ::link-encoded
+ (fn [db _]
+   (:encoded (:editor db))))

--- a/test/cljs/text_to_wardley/db_test.cljs
+++ b/test/cljs/text_to_wardley/db_test.cljs
@@ -1,0 +1,84 @@
+(ns text-to-wardley.db-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [clojure.test.check :as tc]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop :include-macros true]
+            [clojure.test.check.clojure-test :as pt :include-macros true]
+            [text-to-wardley.db :as db]
+             [goog.crypt.base64 :as b64]
+            ))
+
+(enable-console-print!)
+
+
+(pt/defspec test-encode-decode
+  (prop/for-all [text gen/string]
+                (let [encoded (db/encode-qp-text text)
+                      decoded (db/decode-qp-text encoded)]
+                  (= text decoded))))
+
+;; (deftest encode-decode
+;;   (testing "simple encode decode"
+;;     (let [text "foo"
+;;           encoded (db/encode-qp-text text)
+;;           decoded (db/decode-qp-text encoded)
+;;           ]
+;;       (is (= text decoded)))))
+
+(deftest online-photo-shop
+  (testing "no starting node"
+    (let [text "bar"
+          output (db/populate-editor text)
+          ]
+      
+      )
+    )
+  (testing "online photo shop happy path"
+    (let [text db/starting-editor-value
+          output (db/populate-editor text)
+          parsed {:Power 
+                  {:Evolution {:phase :Commodity, :x-axis "30"}, 
+                   :Visible {:y-axis "10"}}, 
+                  :CRM 
+                  {:Evolution {:phase :Product, :x-axis "65"}, 
+                   :Visible {:y-axis "60"}, 
+                   :Needs {:links [:Compute]}}, 
+                  :Compute 
+                  {:Evolution {:phase :Product, :x-axis "70"}, 
+                   :Visible {:y-axis "20"}, 
+                   :Needs {:links [:Data-Center :Power]}}, 
+                  :Data-Center 
+                  {:Evolution {:phase :Product, :x-axis "25"}, 
+                   :Visible {:y-axis "15"}, 
+                   :Needs {:links [:Power]}}, 
+                  :Online-Image-Manipulation 
+                  {:Evolution {:phase :Custom-Built, :x-axis "10"}, 
+                   :Visible {:y-axis "90"}, 
+                   :Needs {:links [:Online-Photo-Storage]}}, 
+                  :Customer 
+                  {:Evolution {:phase :Custom-Built, :x-axis "65"}, 
+                   :Visible {:y-axis "98"}, 
+                   :Needs {:links [:Online-Image-Manipulation :Online-Photo-Storage :Web-Site :Print]}}, 
+                  :Platform 
+                  {:Evolution {:phase :Product, :x-axis "20"}, 
+                   :Visible {:y-axis "50"}, 
+                   :Needs {:links [:Compute]}}, 
+                  :Online-Photo-Storage 
+                  {:Evolution {:phase :Custom-Built, :x-axis "50"}, 
+                   :Visible {:y-axis "80"}, 
+                   :Needs {:links [:Web-Site]}}, 
+                  :Web-Site 
+                  {:Evolution {:phase :Product, :x-axis "55"}, 
+                   :Visible {:y-axis "70"}, 
+                   :Needs {:links [:CRM :Platform]}}, 
+                  :Print 
+                  {:Evolution {:phase :Product, :x-axis "45"}, 
+                   :Visible {:y-axis "80"}, 
+                   :Needs {:links [:Web-Site]}}
+                  }
+                  ]
+      (is (= (:raw output) text))
+      (is (= (:parsed output) parsed))
+      )))
+
+


### PR DESCRIPTION
Added 'data' as a query-param and a link to save progress

Bugs:
- Parsing can handle text that doesnt result in a node. ie `foo` without
a terminating `:`
- Made the links work correctly for the wardley mapping

Also solves #8 